### PR TITLE
[Fix]チャットのメッセージ表示

### DIFF
--- a/app/assets/javascripts/channels/chat_room.js
+++ b/app/assets/javascripts/channels/chat_room.js
@@ -9,7 +9,8 @@ App.chat_room = App.cable.subscriptions.create("ChatRoomChannel", {
 
   received: function(data) {
     // Called when there's incoming data on the websocket for this channel
-      return $('#chat_messages').append('<li>' + data["content"] + '</li>');
+    console.log(data)
+      return $('#chat_messages').append(data["message"]);
   },
 
   speak: function(chat_room_id, user_id, shop_id, content) {

--- a/app/channels/chat_room_channel.rb
+++ b/app/channels/chat_room_channel.rb
@@ -12,12 +12,9 @@ class ChatRoomChannel < ApplicationCable::Channel
   #room_channel.jsで実行されたspeakのメッセージを受け取り、メッセージ作成？
   def speak(data)
     if data["user_id"].present?
-    ChatMessage.create! content: data["content"], user_id: data["user_id"], chat_room_id: data["chat_room_id"]
-    ActionCable.server.broadcast 'chat_room_channel',content: data["content"]
-
-    elsif data["shop_id"].present?
-    ChatMessage.create! content: data["content"], shop_id: data["shop_id"], chat_room_id: data["chat_room_id"]
-    ActionCable.server.broadcast 'chat_room_channel',content: data["content"]
+      ChatMessage.create! content: data["content"], user_id: data["user_id"], chat_room_id: data["chat_room_id"]
+    else
+      ChatMessage.create! content: data["content"], shop_id: data["shop_id"], chat_room_id: data["chat_room_id"]
     end
   end
 end

--- a/app/jobs/chat_message_broadcast_job.rb
+++ b/app/jobs/chat_message_broadcast_job.rb
@@ -2,18 +2,16 @@ class ChatMessageBroadcastJob < ApplicationJob
   queue_as :default
 
   def perform(chat_message)
-    ActionCable.server.broadcast "chat_room_channel_#{chat_message.chat_room_id}", chat_message: render_chat_message(chat_message)
-    # ActionCable.server.broadcast "chat_room_channel_#{chat_message.chat_room_id}", chat_message: render_chat_message(chat_message.chat_room.chat_messages.where(user_id: chat_message.chat_room.user.id), chat_message.chat_room.chat_messages.where(shop_id: chat_message.chat_room.shop.id))
+      ActionCable.server.broadcast 'chat_room_channel', message: render_chat_message(chat_message)
   end
 
   private
 
-  def render_chat_message(chat_message )
-    #if user_messages.present?
-    ApplicationController.render_with_signed_in_user(chat_message.user, partial: 'chat_messages/chat_message', locals: { user_messages: chat_message})
-    #else shop_messages.present?
-    ApplicationController.render_with_signed_in_shop(chat_message.shop,partial: 'chat_messages/chat_message', locals: { shop_message: chat_message })
-  #end
+  def render_chat_message(chat_message)
+    if chat_message.user_id.present?
+      ApplicationController.renderer.render partial: 'chat_messages/chat_message_left', locals: { target_path: Rails.application.routes.url_helpers.user_path(chat_message.user), image_name: :user_image , image: chat_message.user, content:chat_message.content, created_at: chat_message.created_at }
+    else
+      ApplicationController.renderer.render partial: 'chat_messages/chat_message_left', locals: { target_path: Rails.application.routes.url_helpers.shop_path(chat_message.shop), image_name: :main_image , image: chat_message.shop, content:chat_message.content, created_at: chat_message.created_at }
+    end
   end
-
 end

--- a/app/views/chat_messages/_chat_message.html.erb
+++ b/app/views/chat_messages/_chat_message.html.erb
@@ -3,56 +3,19 @@
     <%# shopでログインしている場合の表示 %>
     <% if shop_signed_in? %>
       <% shop_messages.each do |sm| %>
-        <div class="chat-box-right">
-          <div class="faceicon-right">
-            <%= link_to shop_path(sm.shop) do %>
-            <%= attachment_image_tag sm.shop, :main_image, class: "round_image", fallback: "no_image.svg", size:"50x50" %>
-            <% end %>
-          </div>
-          <div class="mycomment">
-           <strong><%= sm.content %></strong> <br>
-              <%= sm.created_at.strftime("%Y-%m-%d %H:%M")%>
-          </div>
-        </div>
+        <%= render 'chat_messages/chat_message_right', {target_path: shop_path(sm.shop),image_name: :main_image , image: sm.shop, content:sm.content, created_at: sm.created_at  } %>
         <% end %>
         <% user_messages.each do |um| %>
-         <div class="chat-box-left">
-          <div class="faceicon-left">
-            <%= link_to user_path(um.user) do %>
-            <%= attachment_image_tag um.user, :user_image, class: "round_image", fallback: "no_image.svg", size:"50x50" %>
-            <% end %>
-          </div>
-          <div class="says"> <strong><%= um.content %></strong> <br>
-            <%= um.created_at.strftime("%Y-%m-%d %H:%M")%>
-          </div>
-        </div>
+        <%= render 'chat_messages/chat_message_left', {target_path: user_path(um.user), image_name: :user_image , image: um.user, content:um.content, created_at: um.created_at  } %>
       <% end %>
  
       <%# userでログインしている場合の表示 %>
       <% elsif user_signed_in? %>
         <% user_messages.each do |um| %>
-          <div class="chat-box-right">
-            <div class="faceicon-right">
-            <%= link_to user_path(um.user) do %>
-              <%= attachment_image_tag um.user, :user_image, class: "round_image", fallback: "no_image.svg", size:"50x50" %>
-            <% end %>
-            </div>
-            <div class="mycomment"> <strong><%= um.content %></strong> <br>
-              <%= um.created_at.strftime("%Y-%m-%d %H:%M")%>
-            </div>
-          </div>
+          <%= render 'chat_messages/chat_message_right', {target_path: user_path(um.user), image_name: :user_image , image: um.user, content:um.content, created_at: um.created_at  } %>
         <% end %>
         <% shop_messages.each do |sm| %>
-          <div class="chat-box-left">
-            <div class="faceicon-left">
-            <%= link_to shop_path(sm.shop) do %>
-              <%= attachment_image_tag sm.shop, :main_image, class: "round_image", fallback: "no_image.svg", size:"50x50" %>
-            <% end %>
-            </div>
-            <div class="says"> <strong><%= sm.content %></strong> <br>
-              <%= sm.created_at.strftime("%Y-%m-%d %H:%M")%>
-            </div>
-          </div>
-        <% end %>
+        <%= render 'chat_messages/chat_message_left', {target_path: shop_path(sm.shop),image_name: :main_image , image: sm.shop, content:sm.content, created_at: sm.created_at  } %>
+      <% end %>
     <% end %>
   </div>

--- a/app/views/chat_messages/_chat_message_left.html.erb
+++ b/app/views/chat_messages/_chat_message_left.html.erb
@@ -1,0 +1,11 @@
+<div class="chat-box-left">
+    <div class="faceicon-left">
+        <%= link_to target_path do %>
+            <%= attachment_image_tag image, image_name, class: "round_image", fallback: "no_image.svg", size:"50x50" %>
+        <% end %>
+    </div>
+    <div class="says">
+        <strong><%= content %></strong> <br>
+        <%= created_at.strftime("%Y-%m-%d %H:%M")%>
+    </div>
+</div>

--- a/app/views/chat_messages/_chat_message_right.html.erb
+++ b/app/views/chat_messages/_chat_message_right.html.erb
@@ -1,0 +1,11 @@
+<div class="chat-box-right">
+    <div class="faceicon-right">
+        <%= link_to target_path do %>
+            <%= attachment_image_tag image, image_name, class: "round_image", fallback: "no_image.svg", size:"50x50" %>
+        <% end %>
+    </div>
+    <div class="mycomment">
+        <strong><%= content %></strong> <br>
+        <%= created_at.strftime("%Y-%m-%d %H:%M")%>
+    </div>
+</div>


### PR DESCRIPTION
-チャットメッセージの表示方法を変更
メッセージ1つずつをパーシャル化して左右に分ける

**・chat_room_channel.rbの時点でブロードキャストは扶養のため、削除。**
```
   ChatMessage.create! content: data["content"], user_id: data["user_id"], chat_room_id: data["chat_room_id"]
   ActionCable.server.broadcast 'chat_room_channel',content: data["content"]

    elsif data["shop_id"].present?
    ChatMessage.create! content: data["content"], shop_id: data["shop_id"], chat_room_id: data["chat_room_id"]
    ActionCable.server.broadcast 'chat_room_channel',content: data["content"]
```


**・chat_message_broadcast_job.rb で以下をmessageに渡す**
`locals: { target_path: Rails.application.routes.url_helpers.user_path(chat_message.user), image_name: :user_image , image: chat_message.user, content:chat_message.content, created_at: chat_message.created_at }`

`locals: { target_path: Rails.application.routes.url_helpers.shop_path(chat_message.shop), image_name: :main_image , image: chat_message.shop, content:chat_message.content, created_at: chat_message.created_at }`

**・chat_room.js でdata[message]をappend**