### PR TITLE
fix/#39/chat

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,6 +35,7 @@
 
 .round_image{
      border-radius: 50%;
+     object-fit: cover;
 }
 .circle{
     width: 80px;

--- a/app/jobs/chat_message_broadcast_job.rb
+++ b/app/jobs/chat_message_broadcast_job.rb
@@ -4,9 +4,9 @@ class ChatMessageBroadcastJob < ApplicationJob
   #private以下の記述で左右のパーシャル両方をmessage_right、 message_leftに渡す。また左右の表示を分けるためにsend_idを渡す。
   def perform(chat_message)
     if chat_message.user_id.present? 
-      ActionCable.server.broadcast "chat_room_channel_#{chat_message.chat_room_id}", message_right: render_message_right(chat_message), message_left: render_message_left(chat_message),send_id: @arguments[0].user_id
+      ActionCable.server.broadcast "chat_room_channel_#{chat_message.chat_room_id}", message_right: render_message_right(chat_message), message_left: render_message_left(chat_message),send_id: "user"
     else
-      ActionCable.server.broadcast "chat_room_channel_#{chat_message.chat_room_id}", message_right: render_message_right(chat_message), message_left: render_message_left(chat_message),send_id: @arguments[0].shop_id
+      ActionCable.server.broadcast "chat_room_channel_#{chat_message.chat_room_id}", message_right: render_message_right(chat_message), message_left: render_message_left(chat_message),send_id: "shop"
     end
   end
 

--- a/app/views/chat_rooms/show.html.erb
+++ b/app/views/chat_rooms/show.html.erb
@@ -13,9 +13,9 @@
 <div id="room" data-room_id="<%= @room.id %>"></div>
 <%# メッセージの表示を返す時、左右を分けるために誰がページを見ているか情報を渡す %>
 <% if shop_signed_in? %>
-  <div id="show_id" data-show_id="<%= current_shop.id %>"></div>
+  <div id="show_id" data-show_id="shop"></div>
 <% elsif user_signed_in? %>
-  <div id="show_id" data-show_id="<%= current_user.id %>"></div>
+  <div id="show_id" data-show_id="user"></div>
 <% end %>
 
 


### PR DESCRIPTION
チャット表示分けの方法を変更

userとshop間のみのやりとりのため、IDで分ける必要がないため、
send_idとshow_idそれぞれにuserとshopの文字列を入れることで解決