### PR TITLE
Add/block wrong

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -50,3 +50,11 @@
 //         return chatForm.val('');
 //       }
 //     }));
+
+// function addToSearchUrl() {
+//     let path = location.pathname;
+//     let pattern = /users\/search.*$/
+  
+//     // URLが正しければ変更は不要
+//     if(path.match(pattern)){history.replaceState('', '', `${ path }`)} return;
+//   };

--- a/app/controllers/chat_messages_controller.rb
+++ b/app/controllers/chat_messages_controller.rb
@@ -1,7 +1,6 @@
 class ChatMessagesController < ApplicationController
 
     def create
-        binding.pry
         #送信内容とchat_room_idを渡す
         @message = ChatMessage.new(message_params)
         #ログイン＝送信者として@messageに渡す

--- a/app/controllers/chat_rooms_controller.rb
+++ b/app/controllers/chat_rooms_controller.rb
@@ -1,5 +1,5 @@
 class ChatRoomsController < ApplicationController
-
+  before_action :block_wrong_chat, only: [:show]
   def create
     #お店が作成した場合は、cuurent_shop.idとhiddenオプションで送られてきたuser_idを保存
     if shop_signed_in?
@@ -36,6 +36,24 @@ class ChatRoomsController < ApplicationController
         myRoomIds << chat_room.id
       end
       @user_chat_rooms = ChatRoom.where(id: myRoomIds).order(created_at: :desc)
+    end
+  end
+
+  private
+  def block_wrong_chat
+    chat_room = ChatRoom.find_by(id: params[:id])
+    if user_signed_in?
+      if chat_room.user_id != current_user.id
+      flash[:alert] = "権限がありません"
+      redirect_to root_path
+      end
+    elsif shop_signed_in?
+      if chat_room.shop_id != current_shop.id
+        flash[:alert] = "権限がありません"
+        redirect_to root_path
+      end
+    elsif admin_signed_in?
+      flash[:alert] = "管理者でログインしています"
     end
   end
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,5 +1,6 @@
 class ShopsController < ApplicationController
   before_action :authenticate_shop!, only: [:edit, :update, :withdraw]
+  before_action :block_wrong_shop, only: [:edit, :update, :withdraw]
   before_action :set_shop, only: [:show, :edit, :update, :withdraw, :followers, :followings ]
 
   def show
@@ -72,6 +73,13 @@ class ShopsController < ApplicationController
   private
   def set_shop
     @shop = Shop.find(params[:id])
+  end
+
+  def block_wrong_shop
+    if params[:id].to_i != current_shop.id
+      flash[:alert] = "権限がありません"
+      redirect_to root_path
+    end
   end
 
   def shop_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!, only: [:edit, :update, :withdraw]
+  before_action :block_wrong_user, only: [:edit, :update, :withdraw]
   before_action :set_user, only: [:show, :edit, :update, :withdraw, :followers, :followings ]
 
   def show
@@ -71,6 +72,13 @@ class UsersController < ApplicationController
   private
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def block_wrong_user
+    if params[:id].to_i != current_user.id
+      flash[:alert] = "権限がありません"
+      redirect_to root_path
+    end
   end
 
   def user_params

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,7 +3,7 @@ class Category < ApplicationRecord
     has_many :products
 
   #バリデーション
-  with_options presence: true,on: :update do
+  with_options presence: true do
     validates :code
     validates :name
   end

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -5,7 +5,7 @@ class ChatMessage < ApplicationRecord
   belongs_to :shop, optional: true
 
   #バリデーション
-  with_options presence: true,on: :update do
+  with_options presence: true do
     validates :content
     validates :chat_room_id
   end

--- a/app/models/chat_room.rb
+++ b/app/models/chat_room.rb
@@ -5,7 +5,7 @@ class ChatRoom < ApplicationRecord
   has_many :chat_messages
 
   #バリデーション
-  with_options presence: true,on: :update do
+  with_options presence: true do
     validates :user_id
     validates :shop_id
   end

--- a/app/views/admins/chat_rooms/index.html.erb
+++ b/app/views/admins/chat_rooms/index.html.erb
@@ -13,7 +13,7 @@
             <% @chat_rooms.each do |cr| %>
                 <tr>
                     <td>
-                        <%= link_to cr.id, chat_room_path(cr.id)  %>
+                        <%= link_to cr.id, chat_room_path(cr.id), data: {"turbolinks" => false}  %>
                     </td>
                     <td>
                         <%= link_to admins_user_path(cr.user.id) do %>

--- a/app/views/chat_rooms/index.html.erb
+++ b/app/views/chat_rooms/index.html.erb
@@ -5,7 +5,7 @@
             <tr>
                 <td>
                 <!-- 名前からroomの詳細に飛べるようにリンク化 -->
-                <%= link_to chat_room_path(e.id) do %>
+                <%= link_to chat_room_path(e.id), data: {"turbolinks" => false} do %>
                     <%= attachment_image_tag e.user, :user_image, format: 'jpeg', class: "round_image", fallback: "no_image.jpg", size: "30x30" %>
                     <%= e.user.full_name %>
                 <% end %>
@@ -22,9 +22,10 @@
             <tr>
                 <td>
                     <!-- 名前からroomの詳細に飛べるようにリンク化 -->
-                    <%= link_to chat_room_path(e.id) do %>
+                    <%= link_to chat_room_path(e.id), data: {"turbolinks" => false} do %>
                         <%= attachment_image_tag e.shop, :main_image, format: 'jpeg', class: "round_image", fallback: "no_image.jpg", size: "30x30" %>
                         <%= e.shop.name %>
+                        <span id="room" data-room_id="<%= e.id %>"></span>
                     <% end %>
                 </td>
                 <td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -48,7 +48,7 @@
         <% end %>
     </div>
 </div>
- <div class="container">
+<div class="container">
     <% @users.each do |user| %>
     <% if user.full_name.present? %>
     <div class= "row">
@@ -94,3 +94,8 @@
     <% end %>
     <% end %>
  </div>
+
+
+ <%# <script>
+    window.onload = addToSearchUrl();
+ </script> %>


### PR DESCRIPTION
-URLの直打ちを制限
block_wrong_〇〇メソッド で各種直打ちを制限。
chat_roomはadminは入室できるようにする

-バリデーションの条件が間違っていたの変更
`with_options presence: true,on: :update do`

`with_options presence: true do`

-チャットメッセージのフロント制御のエラー修正
一覧から入室した場合、送信制御がうまく発生しないエラーを修正