### PR TITLE
[Fix]#115/ハイパーリンクの受信側の表示エラー

### DIFF
--- a/app/helpers/chat_messages_helper.rb
+++ b/app/helpers/chat_messages_helper.rb
@@ -3,11 +3,13 @@ module ChatMessagesHelper
     require "uri"
  
     def content_url_to_link(content)
+        # 左右のパーシャルで呼び出すため、contentが二重に書き換えられるのを防ぐため、dupメソッドでコピーしてcontentを複数用意する
+        dup_content = content.dup
         # URI.extractで引数の[“http”, “https”].uniqで引数のcontentが「httpかhttps」のいずれかで始まるテキスト要素を重複を削除した形で配列を生成
-        URI.extract(content, ["http", "https"]).uniq.each do |url|
+        URI.extract(dup_content, ["http", "https"]).uniq.each do |url|
             # 「gsub!」メソッドでcontentをの値を”< a href=”#{url}”target=”_blank”>#{url}</a>”に置換
-            content.gsub!(url, "<a href='#{url}' target='_blank'>#{url}</a>")
+            dup_content.gsub!(url, "<a href='#{url}' target='_blank'>#{url}</a>")
         end
-        content
+        dup_content
     end
 end

--- a/app/views/chat_messages/_chat_message_left.html.erb
+++ b/app/views/chat_messages/_chat_message_left.html.erb
@@ -5,7 +5,9 @@
         <% end %>
     </div>
     <div class="says">
+    <%# binding.pry if content.match(/^http/) %>
         <strong><%= content_url_to_link(content).html_safe %></strong> <br>
+
         <%= created_at.strftime("%Y-%m-%d %H:%M")%>
     </div>
 </div>

--- a/app/views/chat_messages/_chat_message_right.html.erb
+++ b/app/views/chat_messages/_chat_message_right.html.erb
@@ -5,7 +5,6 @@
         <% end %>
     </div>
     <div class="mycomment">
-        <%# binding.pry if content.match(/^http/) %>
         <strong><%= content_url_to_link(content).html_safe %></strong> <br>
         <%= created_at.strftime("%Y-%m-%d %H:%M")%>
     </div>


### PR DESCRIPTION
チャットメッセージのハイパーリンクの受信側の表示エラーを解消。

https://github.comというメッセージを送信した際の相手の表示が以下となっていた。
https://github.com/'' target='_blank'>https://github.com/' target='_blank'>https://github.com/

原因は、左右両方のパーシャルで呼び出しているため、
<%= content_url_to_link(content).html_safe %>

送信（右のパーシャル）で破壊的メソッドでcontentの内容を書き換えて、さらに左で書き換えているからリロードしないと2重になる。


dupメソッドでコピーして書き換えるcontentを複数用意して二重の処理を防ぐ。
少々力技の感じがあるため、破壊的メソッドを使わない方法で改善予定。